### PR TITLE
Docker command changes

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -144,11 +144,11 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-        restart: true
       prometheus:
         condition: service_started
     networks:
       - nifi_network
+
 
   # ---------------------------------------------
   # Apache Zookeeper

--- a/deployment/nifi/Dockerfile.nifi
+++ b/deployment/nifi/Dockerfile.nifi
@@ -3,7 +3,10 @@ FROM apache/nifi:1.19.0
 USER root
 
 # Install Python and pip
-RUN apt-get update && apt-get install -y python3 python3-pip
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true \
+ && apt-get -o Acquire::Retries=5 update \
+ && apt-get install -y python3 python3-pip
+
 
 # Install required Python libraries
 RUN pip3 install xmltodict asn1tools

--- a/deployment/nifi/Dockerfile.nifi-init
+++ b/deployment/nifi/Dockerfile.nifi-init
@@ -1,6 +1,9 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y curl jq
+# switch mirrors to HTTPS, then update/install
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true \
+ && apt-get -o Acquire::Retries=5 update \
+ && apt-get install -y curl jq
 
 COPY ./nifi/nifi-init.sh /opt/scripts/nifi-init.sh
 RUN chmod +x /opt/scripts/nifi-init.sh


### PR DESCRIPTION
Couple of changes in the docker script to enable it to run.

1. Docker complained that "restart: true" is not a valid command
2. apt-get update commands require https only else it fails. This resulted in the docker images attempting to update the OS to fail.