### PR TITLE
fix(deps): remediate Werkzeug safe_join and pytest tmpdir advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Event Publisher (pip / requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/deployment/eventPublisher"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # NiFi scripts (Poetry / pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/deployment/nifi/nifi-scripts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions workflows (for when CI is added)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- No publicly known run-time vulnerabilities have been reported or fixed.
+- Updated Werkzeug to 3.1.6 to remediate the moderate `safe_join` Windows device-name advisories (CVE-2025-66221, CVE-2026-21860, CVE-2026-27199).
+- Updated pytest (dev dependency) to 9.0.3 to remediate the tmpdir handling advisory (CVE-2025-71176).
+- Added `.github/dependabot.yml` to monitor dependencies for future advisories.
+- No publicly known run-time vulnerabilities affect the first-party code itself.
 
 ## 2.0.0 - 2025-03-28
 

--- a/deployment/eventPublisher/requirements.txt
+++ b/deployment/eventPublisher/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.0.1
 prometheus_client==0.13.1
-Werkzeug==3.1.3
+Werkzeug==3.1.6
 confluent_kafka==2.0.2
 asn1tools==0.167.0
 waitress==3.0.2

--- a/deployment/nifi/nifi-scripts/pyproject.toml
+++ b/deployment/nifi/nifi-scripts/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{include = "src"}]
 
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.5"
+pytest = "^9.0.3"
 pytest-cov = "^6.1.1"
 ruff = "^0.6.0"
 bandit = "^1.7.0"


### PR DESCRIPTION
Bump Werkzeug 3.1.3 -> 3.1.6 to clear the moderate safe_join Windows device-name advisories (CVE-2025-66221, CVE-2026-21860, CVE-2026-27199), including the compound-extension/trailing-space bypass that affected send_from_directory. Bump the pytest dev dependency 8.3.5 -> 9.0.3 to clear the tmpdir TOCTOU advisory (CVE-2025-71176).

This clears the open Dependabot moderate alerts so no medium-or-higher vulnerability remains publicly known and unpatched beyond 60 days (OpenSSF vulnerabilities_fixed_60_days).

Add .github/dependabot.yml (pip + github-actions, weekly) to monitor dependencies going forward, and record the changes in CHANGELOG.md.

Verified: Flask 3.0.1 + Werkzeug 3.1.6 import and app creation OK; pytest suite 5 passed; ruff clean; bandit 0 medium/high.