### PR TITLE
ci: add keyless release-signing workflow (cosign / Sigstore)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+# Cut a release by pushing a tag, e.g.:  git tag v2.1.0 && git push origin v2.1.0
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create the GitHub Release and upload assets
+  id-token: write # keyless signing via Sigstore (GitHub OIDC)
+
+jobs:
+  signed-release:
+    name: Build and sign release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Build source archive and checksum
+        run: |
+          version="${GITHUB_REF_NAME}"
+          archive="instantx-${version}.tar.gz"
+          git archive --format=tar.gz --prefix="instantx-${version}/" -o "${archive}" "${GITHUB_REF}"
+          sha256sum "${archive}" > "${archive}.sha256"
+          echo "archive=${archive}" >> "${GITHUB_ENV}"
+
+      - name: Sign source archive (keyless / Sigstore)
+        run: |
+          cosign sign-blob --yes \
+            --output-signature "${archive}.sig" \
+            --output-certificate "${archive}.pem" \
+            "${archive}"
+
+      - name: Publish GitHub Release with signed assets
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            instantx-*.tar.gz
+            instantx-*.tar.gz.sha256
+            instantx-*.tar.gz.sig
+            instantx-*.tar.gz.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allowlist input validation and a request-size limit on the Event Publisher API.
 - `GOVERNANCE.md`, `ROADMAP.md`, `docs/Threat-Model.md`, and `docs/Security-Architecture.md`.
 - Developer Certificate of Origin (DCO) sign-off requirement (documented in `CONTRIBUTING.md`, enforced in CI).
+- Release-signing workflow (`.github/workflows/release.yml`): on every `v*` tag, builds a source archive and signs it with cosign (keyless, Sigstore) before publishing a GitHub Release.
 
 ### Changed
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,16 +4,20 @@ InstantX uses [Semantic Versioning](https://semver.org/). The notes below summar
 
 ## Release process & signature verification
 
-Releases are identified by **signed Git tags**, signed with [Sigstore `gitsign`](https://github.com/sigstore/gitsign) (keyless signing via OIDC — no long-lived keys to manage). To verify a release tag, install `gitsign` and verify the tag, e.g.:
+A release is cut by pushing a `v*` tag (e.g. `git tag v2.1.0 && git push origin v2.1.0`). The [release workflow](./.github/workflows/release.yml) then builds a source archive and **signs it with [cosign](https://github.com/sigstore/cosign)** — keyless, via GitHub OIDC (no long-lived keys), with the signature recorded in the Sigstore [Rekor](https://docs.sigstore.dev/logging/overview/) transparency log. It attaches the archive, its SHA-256 checksum, the signature (`.sig`), and the signing certificate (`.pem`) to the GitHub Release.
+
+To verify a downloaded release archive:
 
 ```sh
-gitsign verify-tag \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  --certificate-identity-regexp="lf-edge/instantx" \
-  <tag>
+cosign verify-blob \
+  --certificate "instantx-<version>.tar.gz.pem" \
+  --signature "instantx-<version>.tar.gz.sig" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity-regexp "https://github.com/lf-edge/instantx/.github/workflows/release.yml@.*" \
+  "instantx-<version>.tar.gz"
 ```
 
-Adjust the `--certificate-identity`/`--certificate-oidc-issuer` to match the maintainer or CI workflow that produced the signature (see the gitsign documentation). The release-manager role is described in [GOVERNANCE.md](./GOVERNANCE.md).
+The release-manager role is described in [GOVERNANCE.md](./GOVERNANCE.md).
 
 ## Upgrade path
 


### PR DESCRIPTION
On every `v*` tag, the new .github/workflows/release.yml builds a source archive, signs it with cosign keyless via GitHub OIDC (recorded in Rekor), and publishes a GitHub Release with the archive, SHA-256 checksum, signature, and signing certificate. This satisfies the OpenSSF Silver `signed_releases` criterion without managing long-lived keys.

Update RELEASE.md with the cosign verify-blob verification process and note the workflow in CHANGELOG.