### PR TITLE
docs: MQTT & HTTP integration testing guides; fix Kafka Connect health + Alpine build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # InstantX (LF Edge) - Agent Instructions
 
+> **Setup:** This file is the single, version-controlled source of agent instructions. Claude Code reads `CLAUDE.md`, which is git-ignored on purpose — symlink it to this file after cloning. See [section 8](#8-agent-instruction-files-claudemd--agentsmd).
+
 ## 1. Agent Persona & Operational Guidelines
 - **Assigned Role:** Technical assistant operating under the strict guidelines of a Cloud Solution Architect and Tech Lead PO.
 - **Tone and Style:** Concise, direct, and rigorously professional.
@@ -62,3 +64,26 @@ When modifying code or configurations, enforce the following constraints:
 - **Workflow:** Fork → feature branch → PR against `main`.
 - **Versioning:** Semantic Versioning (SemVer). Record user-facing changes in `CHANGELOG.md` (Keep a Changelog format) and `RELEASE.md`.
 - **Standards:** Maintain clean commit histories, strict license headers (First-party code is MIT), and adhere to `CONTRIBUTING.md`.
+
+## 8. Agent Instruction Files (CLAUDE.md ↔ AGENTS.md)
+- **Single source of truth:** `AGENTS.md` (this file) is the canonical, committed agent guide. **Do not maintain a separate `CLAUDE.md` with its own content** — it drifts.
+- **Why `CLAUDE.md` is git-ignored:** Claude Code looks for `CLAUDE.md`, but committing it would duplicate `AGENTS.md`. `.gitignore` excludes `CLAUDE.md` (and `CLAUDE.local.md`); each developer links it to `AGENTS.md` locally so Claude Code reads the same instructions every other agent uses.
+- **One-time setup (run from repo root after cloning):**
+
+  **macOS / Linux:**
+  ```bash
+  ln -s AGENTS.md CLAUDE.md
+  ```
+
+  **Windows — PowerShell** (Developer Mode on, or run as Administrator):
+  ```powershell
+  New-Item -ItemType SymbolicLink -Path CLAUDE.md -Target AGENTS.md
+  ```
+
+  **Windows — cmd.exe** (run as Administrator):
+  ```cmd
+  mklink CLAUDE.md AGENTS.md
+  ```
+
+- **Result:** Edit `AGENTS.md` only; `CLAUDE.md` follows automatically. The symlink is local-only and never committed (it matches the `.gitignore` entry).
+- **`CLAUDE.local.md`:** Reserved for per-developer overrides that must never be shared — also git-ignored. Do not put project-wide guidance there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ Quality is a shared responsibility. To keep the project maintainable:
 
 The first-party Python test suite lives in [`deployment/nifi/nifi-scripts`](./deployment/nifi/nifi-scripts) and is run with `pytest`. See the [Development guide](./docs/Development.md) for how to run tests, linting, and static analysis locally.
 
-For manual, end-to-end checks against the running stack, the [Manual MQTT Testing](./docs/MQTT-Manual-Testing.md) guide walks through connecting to the broker and watching a message travel from a publisher to a subscriber.
+For manual, end-to-end checks against the running stack, see the [Manual MQTT Testing](./docs/MQTT-Manual-Testing.md) guide (connect to the broker and watch a message travel from a publisher to a subscriber) and the [HTTP Integration Testing](./docs/HTTP-Integration-Testing.md) guide (POST a message to the Event Publisher API and read it back from MQTT).
 
 ### Coding Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,8 @@ Quality is a shared responsibility. To keep the project maintainable:
 
 The first-party Python test suite lives in [`deployment/nifi/nifi-scripts`](./deployment/nifi/nifi-scripts) and is run with `pytest`. See the [Development guide](./docs/Development.md) for how to run tests, linting, and static analysis locally.
 
+For manual, end-to-end checks against the running stack, the [Manual MQTT Testing](./docs/MQTT-Manual-Testing.md) guide walks through connecting to the broker and watching a message travel from a publisher to a subscriber.
+
 ### Coding Standards
 
 To keep contributions consistent and clean:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See **[ROADMAP.md](./ROADMAP.md)** for the project's direction (now / next / lat
 - [Deployment QuickStart](./deployment/Quick-Start.md)
 - [Development guide](./docs/Development.md) — build, test, lint, and static analysis
 - [Manual MQTT Testing](./docs/MQTT-Manual-Testing.md) — connect to the broker and validate the publish/subscribe flow with `mosquitto` clients
+- [HTTP Integration Testing](./docs/HTTP-Integration-Testing.md) — POST a message to the Event Publisher API and read it back from MQTT
 
 - User guides
   - [MQTT Topic Structure](./docs/MQTT-Topic-Structure.md)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See **[ROADMAP.md](./ROADMAP.md)** for the project's direction (now / next / lat
 
 - [Deployment QuickStart](./deployment/Quick-Start.md)
 - [Development guide](./docs/Development.md) — build, test, lint, and static analysis
+- [Manual MQTT Testing](./docs/MQTT-Manual-Testing.md) — connect to the broker and validate the publish/subscribe flow with `mosquitto` clients
 
 - User guides
   - [MQTT Topic Structure](./docs/MQTT-Topic-Structure.md)

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -238,7 +238,6 @@ services:
       context: .
       dockerfile: ./nifi/Dockerfile.nifi-init
     container_name: instantx_setup
-    platform: linux/amd64
     depends_on:
       nifi:
         condition: service_healthy

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
       CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.storage.StringConverter
-      CONNECT_REST_ADVERTISED_HOST_NAME: kafka
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
       CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
       CONNECT_LOG4J_LOGGERS: "org.apache.kafka.connect.runtime.rest=WARN,org.reflections=ERROR"
       CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN: "[%d] %p %X{connector.context}%m (%c:%L)%n"

--- a/deployment/eventPublisher/Dockerfile
+++ b/deployment/eventPublisher/Dockerfile
@@ -1,16 +1,10 @@
 # Use an appropriate base image
-FROM python:3.9-alpine
+# Debian slim: pip installs the prebuilt confluent_kafka wheel, which bundles a
+# matching librdkafka. No system librdkafka or C toolchain required.
+FROM python:3.9-slim-bookworm
 
-# Install librdkafka and other dependencies
-RUN apk add --no-cache \
-    librdkafka-dev \
-    gcc \
-    musl-dev \
-    libc-dev \
-    linux-headers
-
-# Create a non-root user and group with specific ID for consistency
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+# Create a non-root user and group for consistency
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 
 # Set the working directory
 WORKDIR /app

--- a/deployment/nifi/Dockerfile.nifi-init
+++ b/deployment/nifi/Dockerfile.nifi-init
@@ -1,9 +1,7 @@
-FROM ubuntu:latest
+FROM alpine:3.20
 
-# switch mirrors to HTTPS, then update/install
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true \
- && apt-get -o Acquire::Retries=5 update \
- && apt-get install -y curl jq
+# bash (script shebang), curl + jq (NiFi REST calls); --no-cache keeps layer lean
+RUN apk add --no-cache bash curl jq
 
 COPY ./nifi/nifi-init.sh /opt/scripts/nifi-init.sh
 RUN chmod +x /opt/scripts/nifi-init.sh

--- a/docs/HTTP-Integration-Testing.md
+++ b/docs/HTTP-Integration-Testing.md
@@ -1,0 +1,191 @@
+[Home](../README.md) > HTTP Integration Testing
+
+# HTTP Integration Testing (Event Publisher → MQTT)
+
+This guide walks through the real ingress path of InstantX: you POST a V2X (DENM) message to the **Event Publisher** HTTP API (`api-service`), and read the same message back from the **MQTT** broker. Following it end-to-end proves that HTTP ingress, Kafka, the MQTT Sink connector, and the broker are all wired correctly.
+
+For raw MQTT publish/subscribe (installing the clients, broker connection details), see [Manual MQTT Testing](./MQTT-Manual-Testing.md); this guide reuses its subscriber setup.
+
+## 1. How a message flows
+
+```
+curl  ──HTTP POST──▶  Event Publisher (api-service:5000)
+                          │  validates input, UPER-encodes the DENM,
+                          │  hexlifies it to an ASCII string
+                          ▼
+                      Kafka topic  v2x.denm.public
+                          key = v2x/denm/public/g8/7/y/0/1/9/1/k/4   (the geohash path)
+                          │
+                          ▼  MQTTSinkConnector  (topics.regex: v2x.(cam|denm).*)
+                      MQTT broker (HiveMQ)
+                          topic = the Kafka key, verbatim
+                          payload = the UPER hex string
+                          ▼
+                      mosquitto_sub -t "v2x/denm/public/g8/#"
+```
+
+Two facts that drive the rest of this guide:
+
+- The Kafka message **key** (the geohash path) becomes the **MQTT topic**, unchanged. The Kafka topic itself is always `v2x.denm.public`.
+- The MQTT **payload** is the UPER-encoded DENM rendered as a **hexadecimal string** (e.g. `02010001e240c5...`), not JSON. Decoding it back is out of scope — see [UPER Encoding](./Encoding.md).
+
+## 2. Prerequisites
+
+- `curl` (preinstalled on macOS / most Linux; on Windows use Git Bash, WSL, or `curl.exe`).
+- The `mosquitto` clients — install per [Manual MQTT Testing § 1](./MQTT-Manual-Testing.md#1-prerequisites).
+- The Docker stack running (see [section 4](#4-start--verify-the-stack)).
+
+## 3. Connection variables
+
+| Variable | Value | Notes |
+|---|---|---|
+| API base URL | `http://localhost:5000` | The `api-service` container, published as `5000:5000`. |
+| Endpoint | `POST /api/publish/<sub_service>/<sub_service_group>/<geohash>` | `sub_service` must be `denm`; group matches `^[a-z0-9_-]{1,32}$`; geohash matches `^[0-9bcdefghjkmnpqrstuvwxyz]{1,12}$`. |
+| Kafka topic | `v2x.denm.public` | Fixed; the geohash travels as the Kafka **key**, not in the topic name. |
+| MQTT topic (result) | `v2x/denm/public/g8/7/y/0/1/9/1/k/4` | Equals the Kafka key. Subscribe with the wildcard `v2x/denm/public/g8/#`. |
+| Kafka Connect REST | `http://localhost:8083` | Used to check the MQTT Sink connector status. |
+| Connector name | `MQTTSinkConnector` | The Kafka → MQTT bridge; must be `RUNNING`. |
+
+No authentication is configured on the API or the broker in the default stack (see [Manual MQTT Testing § 2](./MQTT-Manual-Testing.md#2-connection-variables)).
+
+## 4. Start / verify the stack
+
+From `deployment/`, bring up the full stack (the bridge needs Kafka **and** Kafka Connect, not just the broker):
+
+```bash
+cd deployment
+docker-compose up -d
+```
+
+Verify the Event Publisher is reachable:
+
+```bash
+docker ps --filter "name=instantx_api-service" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+```
+
+Expected (truncated): `instantx_api-service   Up ...   0.0.0.0:5000->5000/tcp`.
+
+Verify the MQTT Sink connector is `RUNNING` (it is auto-registered ~100 s after Kafka Connect starts — wait if you just launched the stack):
+
+```bash
+curl -s http://localhost:8083/connectors/MQTTSinkConnector/status
+```
+
+Expected: a JSON document whose top-level `connector.state` and each `tasks[].state` are `"RUNNING"`. If you get an empty reply or `404`, the connector has not registered yet — wait and retry, then check `docker-compose logs connect`.
+
+## 5. Send a message (HTTP POST)
+
+Post a schema-valid DENM to geohash `7y0191k4` in the `denm` / `public` group. This body is the project's reference example; it conforms to the DENM ASN.1 schema so it encodes successfully:
+
+```bash
+curl -i -X POST http://localhost:5000/api/publish/denm/public/7y0191k4 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "header": { "protocolVersion": 2, "messageID": 1, "stationID": 123456 },
+    "denm": {
+      "management": {
+        "actionID": { "originatingStationID": 123456, "sequenceNumber": 1 },
+        "detectionTime": 649940045094,
+        "referenceTime": 649940045094,
+        "eventPosition": {
+          "latitude": 367225309,
+          "longitude": -43965883,
+          "positionConfidenceEllipse": {
+            "semiMajorConfidence": 4095,
+            "semiMinorConfidence": 4095,
+            "semiMajorOrientation": 3601
+          },
+          "altitude": { "altitudeValue": 0, "altitudeConfidence": "unavailable" }
+        },
+        "relevanceDistance": "lessThan500m",
+        "validityDuration": 60,
+        "stationType": 10
+      },
+      "situation": {
+        "informationQuality": 0,
+        "eventType": { "causeCode": 95, "subCauseCode": 0 }
+      },
+      "location": {
+        "eventPositionHeading": { "headingValue": 0, "headingConfidence": 127 },
+        "traces": [ [ { "pathPosition": { "deltaLatitude": 2117, "deltaLongitude": 5821, "deltaAltitude": 0 } } ] ]
+      }
+    }
+  }'
+```
+
+The service adds 0.5–1.5 s of jitter per request, so the response is not instant. Expected response:
+
+```
+HTTP/1.1 200 OK
+...
+{"key":"v2x/denm/public/g8/7/y/0/1/9/1/k/4","message":"Message processed successfully","sub_service":"DENM","topic":"v2x.denm.public"}
+```
+
+The `key` in the response is exactly the MQTT topic the message will appear on.
+
+## 6. Read the message from MQTT
+
+In a **separate** terminal, subscribe to the geohash subtree **before** (or while) re-posting. `-v` prints `topic payload`:
+
+```bash
+export MQTT_USER=instantx     # placeholder; ignored by the anonymous broker today
+export MQTT_PASS=instantx
+mosquitto_sub \
+  -h localhost \
+  -p 1883 \
+  -u "$MQTT_USER" \
+  -P "$MQTT_PASS" \
+  -i "instantx-http-sub-$(hostname)-$RANDOM" \
+  -t "v2x/denm/public/g8/#" \
+  -v
+```
+
+With the subscriber running, re-run the [section 5](#5-send-a-message-http-post) POST from another terminal. The subscriber prints the topic followed by the UPER payload as a hex string, for example:
+
+```
+v2x/denm/public/g8/7/y/0/1/9/1/k/4 02010001e240c50000f120000092ea6e41a4c4ba9b906934...
+```
+
+(The exact hex depends on the payload.) Seeing the line confirms the full HTTP → Kafka → MQTT path works. Press `Ctrl+C` to stop the subscriber.
+
+## 7. Input validation reference
+
+The API validates every path segment and the body before encoding. These calls return `400` (or `413`) and never reach Kafka — useful for confirming the API rejects bad input:
+
+| Command (abbreviated) | Response |
+|---|---|
+| `POST /api/publish/unknown/public/7y0191k4` | `400 {"error":"unsupported sub_service"}` |
+| `POST /api/publish/denm/bad.group/7y0191k4` | `400 {"error":"invalid sub_service_group"}` |
+| `POST /api/publish/denm/public/ailo` | `400 {"error":"invalid geohash"}` (a, i, l, o are not in the geohash alphabet) |
+| body `[1,2,3]` | `400 {"error":"request body must be a JSON object"}` |
+| body that does not match the DENM schema (e.g. `{"a":1}`) | `400 {"error":"payload does not conform to the message schema"}` |
+| body larger than 1 MiB | `413 Payload Too Large` |
+
+Example (invalid geohash):
+
+```bash
+curl -i -X POST http://localhost:5000/api/publish/denm/public/ailo \
+  -H "Content-Type: application/json" \
+  -d '{"a": 1}'
+```
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `curl: (7) Failed to connect to localhost port 5000` | `api-service` is down or the port is not published. Re-run [section 4](#4-start--verify-the-stack) and check `docker-compose logs api-service`. |
+| `400 {"error":"payload does not conform to the message schema"}` | The JSON body is not a valid DENM. Use the exact body from [section 5](#5-send-a-message-http-post). |
+| POST returns `200` but nothing appears on MQTT | The MQTT Sink connector is not `RUNNING`, or you subscribed to the wrong topic. Check `curl http://localhost:8083/connectors/MQTTSinkConnector/status` and subscribe to `v2x/denm/public/g8/#`. |
+| Connector status is empty / `404` | Kafka Connect has not registered the connector yet (~100 s after start) or it failed — see `docker-compose logs connect`. |
+| MQTT payload looks like gibberish | It is the UPER-encoded DENM as a hex string — expected. It is not meant to be human-readable JSON; see [UPER Encoding](./Encoding.md). |
+
+## Related
+
+- [Manual MQTT Testing](./MQTT-Manual-Testing.md) — raw MQTT pub/sub and broker connection details.
+- [MQTT Topic Structure](./MQTT-Topic-Structure.md) — how the geohash topic tree is built.
+- [Event Publisher](./Event-Publisher.md) — the service's configuration and how to run it locally.
+- [UPER Encoding](./Encoding.md) — what the hex payload contains.
+
+## Next step
+
+Decoding the UPER hex payload back into a readable DENM (round-trip verification) and securing the API/broker with TLS are follow-ups to this guide.

--- a/docs/HTTP-Integration-Testing.md
+++ b/docs/HTTP-Integration-Testing.md
@@ -177,6 +177,7 @@ curl -i -X POST http://localhost:5000/api/publish/denm/public/ailo \
 | `400 {"error":"payload does not conform to the message schema"}` | The JSON body is not a valid DENM. Use the exact body from [section 5](#5-send-a-message-http-post). |
 | POST returns `200` but nothing appears on MQTT | The MQTT Sink connector is not `RUNNING`, or you subscribed to the wrong topic. Check `curl http://localhost:8083/connectors/MQTTSinkConnector/status` and subscribe to `v2x/denm/public/g8/#`. |
 | Connector status is empty / `404` | Kafka Connect has not registered the connector yet (~100 s after start) or it failed — see `docker-compose logs connect`. |
+| Connector is `RUNNING` but the first end-to-end test still fails | On a cold first start Kafka Connect can take a while to fully stabilize. After confirming `MQTTSinkConnector` is `RUNNING`, restart the container (`docker-compose restart connect`) and wait a few minutes before testing again. |
 | MQTT payload looks like gibberish | It is the UPER-encoded DENM as a hex string — expected. It is not meant to be human-readable JSON; see [UPER Encoding](./Encoding.md). |
 
 ## Related

--- a/docs/MQTT-Manual-Testing.md
+++ b/docs/MQTT-Manual-Testing.md
@@ -1,0 +1,148 @@
+[Home](../README.md) > Manual MQTT Testing
+
+# Manual MQTT Testing
+
+This guide shows how to manually validate the InstantX MQTT publish/subscribe flow against the local broker (HiveMQ CE running in Docker) using the `mosquitto` command-line clients. You should be able to install the tools, connect, and watch a message travel from a publisher to a subscriber in under five minutes.
+
+> The broker is the [HiveMQ Community Edition] image started by the `docker-compose` stack (service `mqtt`). You do **not** need to install a broker locally — only the client tools.
+
+## 1. Prerequisites
+
+Install the `mosquitto` clients (`mosquitto_pub` / `mosquitto_sub`). You only need the **clients**, not the broker: the broker already runs in Docker.
+
+| Platform | Command |
+|---|---|
+| macOS (Homebrew) | `brew install mosquitto` |
+| Debian / Ubuntu | `sudo apt install mosquitto-clients` |
+| Windows (winget) | `winget install EclipseFoundation.Mosquitto` |
+
+On macOS, `brew install mosquitto` installs both the broker and the clients; you can ignore the broker. On Windows you can also use the installer from [mosquitto.org/download](https://mosquitto.org/download/) and add its `bin` directory to your `PATH`.
+
+Verify the clients are available:
+
+```bash
+mosquitto_pub --help
+mosquitto_sub --help
+```
+
+## 2. Connection variables
+
+| Variable | Value | Notes |
+|---|---|---|
+| Host | `localhost` | From your host machine. From another container on the stack network, use the service name `mqtt`. |
+| Port | `1883` | Plain MQTT, published by the `mqtt` service in `deployment/docker-compose.yml`. |
+| Username | _(none by default)_ | The default stack runs HiveMQ CE with anonymous access — no credentials required. See note below. |
+| Password | _(none by default)_ | Same as above. |
+| Topic | `v2x/denm/public/g8/7/y/0/1/9/1/k/4` | See [MQTT Topic Structure](./MQTT-Topic-Structure.md). |
+| Client ID | `instantx-<role>-<unique>` | Must be unique per connection (see [Important notes](#7-important-notes)). |
+
+**Credentials.** The committed stack does not enable broker authentication (the MQTT connectors set `mqtt.connector.auth: "false"`), so any username / password you pass is accepted but unused. To keep the commands below copy-pasteable and ready for a future auth-enabled broker, export them as environment variables instead of hard-coding secrets:
+
+```bash
+export MQTT_USER=instantx     # placeholder; ignored by the anonymous broker today
+export MQTT_PASS=instantx     # placeholder; replace once auth is enabled
+```
+
+> Never commit real credentials to the repository or paste them into docs. Once the broker enforces authentication, credentials are supplied at runtime via environment variables / git-ignored `.env` files (see [Security Architecture](./Security-Architecture.md)).
+
+## 3. Start / verify the broker in Docker
+
+From `deployment/`, make sure the broker container is running and port 1883 is published:
+
+```bash
+cd deployment
+docker-compose up -d mqtt        # start just the broker (or `docker-compose up -d` for the full stack)
+docker-compose ps mqtt           # STATE should be "running" / "Up"
+```
+
+Confirm the port mapping (`0.0.0.0:1883->1883/tcp`):
+
+```bash
+docker ps --filter "name=instantx_mqtt" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+```
+
+Expected output (truncated):
+
+```
+NAMES            STATUS         PORTS
+instantx_mqtt    Up 10 seconds  0.0.0.0:1883->1883/tcp, ...
+```
+
+## 4. Subscriber (consumer)
+
+In one terminal, subscribe to the test topic. `-v` prints `topic payload` so you can see which topic each message arrived on:
+
+```bash
+mosquitto_sub \
+  -h localhost \
+  -p 1883 \
+  -u "$MQTT_USER" \
+  -P "$MQTT_PASS" \
+  -i "instantx-sub-$(hostname)-$RANDOM" \
+  -t "v2x/denm/public/g8/#" \
+  -v
+```
+
+The command blocks and waits for messages. The `#` wildcard matches every geohash under `v2x/denm/public/g8/`.
+
+## 5. Publisher (producer)
+
+In a **second** terminal, publish a message to a concrete topic under that subtree:
+
+```bash
+mosquitto_pub \
+  -h localhost \
+  -p 1883 \
+  -u "$MQTT_USER" \
+  -P "$MQTT_PASS" \
+  -i "instantx-pub-$(hostname)-$RANDOM" \
+  -t "v2x/denm/public/g8/7/y/0/1/9/1/k/4" \
+  -m '{"test":"hello-instantx"}'
+```
+
+`mosquitto_pub` connects, sends the message, and exits.
+
+## 6. Validate the flow
+
+1. Export the connection variables from [section 2](#2-connection-variables) and start the subscriber from [section 4](#4-subscriber-consumer). Leave it running.
+2. In a second terminal, export the same variables and run the publisher from [section 5](#5-publisher-producer).
+3. Switch back to the subscriber terminal. You should immediately see:
+
+   ```
+   v2x/denm/public/g8/7/y/0/1/9/1/k/4 {"test":"hello-instantx"}
+   ```
+
+If the line appears, the publish/subscribe flow through the broker works. Press `Ctrl+C` to stop the subscriber.
+
+## 7. Important notes
+
+- **Client IDs must be unique per connection.** The subscriber and publisher cannot share the same `-i` value: MQTT brokers allow only one connection per client ID and will disconnect the older one. Use a randomized pattern, e.g.:
+
+  ```bash
+  -i "instantx-sub-$(hostname)-$RANDOM"
+  ```
+
+- **Running the clients from another container** on the same Docker network (`nifi_network`): use the service name `mqtt` instead of `localhost`, and the internal port `1883`:
+
+  ```bash
+  docker-compose exec connect \
+    mosquitto_pub -h mqtt -p 1883 \
+      -i "instantx-pub-$RANDOM" \
+      -t "v2x/denm/public/g8/7/y/0/1/9/1/k/4" \
+      -m '{"test":"hello-instantx"}'
+  ```
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Connection Refused: not authorised` | The broker now enforces auth and your `-u` / `-P` are wrong or missing. Re-check the credentials supplied to the stack. |
+| `Error: Connection refused` (cannot reach host) | Port `1883` is not published, or the broker container is down. Re-run [section 3](#3-start--verify-the-broker-in-docker). |
+| Subscriber repeatedly connects / disconnects | The subscriber and publisher share the same client ID (`-i`). Give each a unique ID. |
+| `mosquitto_sub: command not found` | The clients are not installed or not on `PATH`. See [section 1](#1-prerequisites). |
+
+## Next step
+
+Secure the connection with TLS over port `8883` (currently **not** enabled in the default stack). Documenting the TLS workflow — broker listener config and client `--cafile` / `--cert` / `--key` flags — is a follow-up to this guide.
+
+[HiveMQ Community Edition]: https://github.com/hivemq/hivemq-community-edition


### PR DESCRIPTION
## Description

Adds two contributor testing guides and fixes three stack-bring-up bugs found while writing them.

**Documentation**
- `docs/MQTT-Manual-Testing.md` — install the `mosquitto` clients, connect to the local HiveMQ broker, validate the pub/sub flow in under five minutes.
- `docs/HTTP-Integration-Testing.md` — POST a V2X (DENM) message to the Event Publisher API (`api-service`) and read it back from MQTT, proving the HTTP → Kafka → MQTT path end-to-end.
- Both linked from the README ("Additional information") and CONTRIBUTING ("Testing Policy"). `AGENTS.md` gains a section documenting the `CLAUDE.md ↔ AGENTS.md` symlink setup.

**Fixes**
- **Closes #11 / Closes #12** — `CONNECT_REST_ADVERTISED_HOST_NAME` was `kafka`, so the Kafka Connect container healthcheck and inter-worker REST calls targeted the wrong host; the worker stayed in `health: starting` and `:8083` looked unreachable. Now advertises `connect` (its own network name) — verified the container goes **healthy** and the REST API responds on `:8083`.
- **Closes #30** — the `eventPublisher` image built `apk add librdkafka-dev gcc musl-dev libc-dev linux-headers`, which fails behind restrictive firewalls. Switched the base image to `python:3.9-slim-bookworm` and rely on the prebuilt `confluent_kafka` wheel (bundles librdkafka) — no system toolchain needed.

**Related chore**
- `nifi-init` base image `ubuntu:latest` → `alpine:3.20` (apk: bash, curl, jq) and dropped the now-unneeded `linux/amd64` platform pin.

## Relationship to PR #13

[#13](https://github.com/lf-edge/instantx/pull/13) by **@razr** independently diagnosed and fixed the same Kafka Connect health issue (#11, #12) — credit to @razr for surfacing the root cause. This PR incorporates the equivalent fix as part of a broader testing-docs + build changeset, so **#13 can be closed as superseded** once this merges. No merit taken away: the diagnosis there stands on its own, and maintainers may prefer to land #13 first instead — in which case I'll rebase and drop the duplicate commit here.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Refactor / chore

## Checklist

- [x] I have read the [Contributing guidelines](../CONTRIBUTING.md).
- [x] **Tests added or updated** for the change, or I have explained below why tests are not applicable.
- [ ] `poetry run pytest` passes locally.
- [ ] `ruff check` and `bandit` report no new issues.
- [x] Documentation updated where relevant (README, `docs/`, `CHANGELOG.md`).
- [x] I am **not** including secrets, credentials, or sensitive data.
- [x] Security-impacting changes have been considered; vulnerabilities are reported privately via [SECURITY.md](../SECURITY.md), not in this PR.

## Notes for reviewers

- **Tests:** No automated tests — changes are documentation plus Docker/compose infrastructure, not covered by the first-party Python suite. Validated **live** against the running stack: the `connect` container reaches `healthy` and `:8083` responds (#11/#12); `POST /api/publish/denm/public/7y0191k4` → `200` and the message appears on MQTT topic `v2x/denm/public/g8/7/y/0/1/9/1/k/4` as the expected UPER hex payload.
- **pytest / ruff / bandit:** no first-party Python source changed, so unaffected — left unchecked rather than claiming a run I didn't perform.
- **Overlap with #13:** see "Relationship to PR #13" above — credit to @razr; happy to defer to #13 for the connect fix if maintainers prefer.
- **Build-verified:** `docker-compose build api-service nifi-setup` succeeds — both base-image swaps build clean.
