### PR TITLE
docs(release): 2.2.0 release notes (+ finalize 2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-22
+
+### Added
+
+- `docs/MQTT-Manual-Testing.md` — connect to the local HiveMQ broker and validate the publish/subscribe flow with the `mosquitto` clients; linked from the README and `CONTRIBUTING.md`.
+- `docs/HTTP-Integration-Testing.md` — POST a V2X (DENM) message to the Event Publisher API and read it back from MQTT, covering the HTTP → Kafka → MQTT path end-to-end; linked from the README and `CONTRIBUTING.md`.
+- Status badges (CI, release, cosign, license, Python, `ruff`, `bandit`) in the README.
+- Section in `AGENTS.md` documenting the `CLAUDE.md ↔ AGENTS.md` symlink setup.
+
+### Changed
+
+- Event Publisher image base changed from `python:3.9-alpine` to `python:3.9-slim-bookworm`, relying on the prebuilt `confluent_kafka` wheel (bundled `librdkafka`) instead of compiling against a system toolchain.
+- `nifi-init` image base changed from `ubuntu:latest` to `alpine:3.20` (installing `bash`, `curl`, `jq` via `apk`) and removed the now-unneeded `linux/amd64` platform pin on the `nifi-setup` service.
+
+### Fixed
+
+- Kafka Connect `CONNECT_REST_ADVERTISED_HOST_NAME` corrected from `kafka` to `connect`, so the container healthcheck and inter-worker REST calls reach the right host; the worker now becomes healthy and the REST API on port 8083 is reachable (#11, #12).
+- Event Publisher image build no longer fails behind restrictive firewalls — the failing `apk add librdkafka-dev gcc musl-dev libc-dev linux-headers` step was removed with the base-image change (#30).
+
+### Security
+
+- Dependency updates via Dependabot: `actions/checkout`, `actions/setup-python`, `softprops/action-gh-release`, and the `ruff` dev dependency.
+
+## [2.1.0] - 2026-06-05
+
 ### Added
 
 - Root-level `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, and `MAINTAINERS.md` for standard discoverability (GitHub community health files).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,38 @@ cd deployment && docker-compose up --build -d
 
 Breaking changes (MAJOR bumps) and any required migration steps are called out in the release notes below and in [CHANGELOG.md](./CHANGELOG.md).
 
+## Release 2.2.0
+
+Backward-compatible release (no migration steps).
+
+Added
+- Contributor testing guides: [Manual MQTT Testing](./docs/MQTT-Manual-Testing.md) (broker pub/sub with the `mosquitto` clients) and [HTTP Integration Testing](./docs/HTTP-Integration-Testing.md) (POST to the Event Publisher API and read the message back from MQTT, end-to-end).
+- README status badges and an `AGENTS.md` section documenting the `CLAUDE.md ↔ AGENTS.md` symlink setup.
+
+Fixed
+- Kafka Connect now starts healthy and exposes its REST API on port 8083 (corrected `CONNECT_REST_ADVERTISED_HOST_NAME`) — resolves #11 and #12.
+- The Event Publisher image builds behind restrictive firewalls (base image moved to `python:3.9-slim-bookworm`, dropping the system build toolchain) — resolves #30.
+
+Changed
+- Slimmer container bases for the Event Publisher and `nifi-init` images; removed the `linux/amd64` platform pin on the `nifi-setup` service.
+
+## Release 2.1.0
+
+Added
+- Community health files (`CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `MAINTAINERS.md`), `GOVERNANCE.md`, and `ROADMAP.md`.
+- Continuous integration (`ci.yml`): pytest with a ≥80% coverage gate, `ruff`, `bandit`, and a DCO sign-off check; first-party unit tests for the Event Publisher and Kafka speed exporter.
+- Keyless release-signing workflow (`release.yml`): every `v*` tag builds a source archive and signs it with cosign (Sigstore).
+- Security hardening: allowlist input validation and a request-size limit on the Event Publisher API; `docs/Threat-Model.md` and `docs/Security-Architecture.md`.
+
+Changed
+- `EventPublisher.py` refactored into an application factory; encoder/exporter refactored into testable functions (runtime behavior preserved).
+
+Fixed
+- NiFi script tests use a path relative to the test file instead of a hardcoded absolute `DATA_FOLDER`.
+
+Security
+- Updated Werkzeug (`safe_join` advisories) and pytest (dev) to remediate known CVEs; added Dependabot monitoring.
+
 ## Release 2.0.0
 
 Added 


### PR DESCRIPTION
## Description

Prepares the v2.2.0 release notes.

- Converts the stale `[Unreleased]` CHANGELOG block to `## [2.1.0] - 2026-06-05` — the v2.1.0 tag was cut without finalizing it.
- Adds `## [2.2.0] - 2026-06-22`: the MQTT and HTTP integration testing guides, the Kafka Connect health fix (#11, #12), the Event Publisher build fix (#30), the slimmer image bases, and the Dependabot bumps.
- Mirrors both summaries in `RELEASE.md`.

No code or runtime changes — documentation only.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## Notes for reviewers

Docs-only; `pytest`/`ruff`/`bandit` scope unaffected. After merge, the release is cut by tagging `v2.2.0` on `main` (triggers the cosign-signed release workflow).
