### PR TITLE
chore(ci): enable CodeQL code scanning and upload bandit SARIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,49 @@ jobs:
   sast:
     name: SAST (bandit)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to publish the SARIF results as code scanning alerts.
+      security-events: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - run: pip install bandit
-      - run: bandit -r deployment/eventPublisher deployment/kafka_speed_exporter deployment/nifi/nifi-scripts/src -c deployment/nifi/nifi-scripts/pyproject.toml
+      # sarif: SARIF report format. toml: parser for the pyproject.toml config on
+      # Python < 3.11 (3.11+ uses the stdlib tomllib). Without it bandit exits 2
+      # and writes an empty report.
+      - run: pip install 'bandit[sarif,toml]'
+      - name: Run bandit
+        id: bandit
+        run: |
+          set +e
+          bandit -r deployment/eventPublisher deployment/kafka_speed_exporter deployment/nifi/nifi-scripts/src \
+            -c deployment/nifi/nifi-scripts/pyproject.toml \
+            -f sarif -o bandit.sarif
+          code=$?
+          set -e
+          # 0 = clean, 1 = findings, >= 2 = bandit itself failed. Findings must not
+          # abort the job before the SARIF upload, but a tool error must — the
+          # report it leaves behind is empty and would wipe the existing alerts.
+          if [ "$code" -ge 2 ]; then
+            echo "::error::bandit exited $code (configuration or runtime error)"
+            exit "$code"
+          fi
+          echo "findings=$code" >> "$GITHUB_OUTPUT"
+      # Pull requests from forks run with a read-only GITHUB_TOKEN, so the upload
+      # is skipped there. The pass/fail gate below still blocks such a PR.
+      - name: Upload bandit SARIF
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: bandit.sarif
+          # Distinct from the CodeQL categories; without it this upload would
+          # replace the CodeQL results for the same commit.
+          category: bandit
+      - name: Fail the build if bandit found issues
+        if: steps.bandit.outputs.findings == '1'
+        run: exit 1
 
   poetry-lock:
     name: Poetry lock is resolvable & current

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly re-scan so newly published CodeQL queries are applied to code that
+    # has not changed since the last push.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # python                -> deployment/{eventPublisher,kafka_speed_exporter,nifi/nifi-scripts}
+        # javascript-typescript -> website/ (React + Vite)
+        # actions               -> .github/workflows/*.yml
+        language: [python, javascript-typescript, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # No compiled first-party source in this repository; the vendored NARs
+          # and connector JARs are binaries whose source lives in the sibling
+          # repositories (instantx-connectors, instantx-metrics).
+          build-mode: none
+          # Wider than the default suite. Drop this line if triage load grows.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CodeQL code scanning (`.github/workflows/codeql.yml`) on every push to `main`, every pull request, and weekly. Analyses run the `security-extended` query suite over the Python services, the React/Vite website, and the GitHub Actions workflows themselves; results appear as code scanning alerts under the repository's Security tab.
+
 ### Changed
 
+- `bandit` now emits SARIF and uploads it to code scanning, so Python SAST findings are tracked as alerts (with dedup and dismissal history) instead of only failing the CI check. The check still fails the build on any finding.
 - Dependabot now applies a conservative `cooldown` to version updates: 30 days for major, 14 for minor and 7 for patch releases (14 days for GitHub Actions, which supports only `default-days`). New releases soak before adoption, giving yanked releases and supply-chain issues time to surface. Security updates are unaffected and still open pull requests immediately.
 
 ## [2.2.0] - 2026-06-22

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
+[![CodeQL](https://github.com/lf-edge/instantx/actions/workflows/codeql.yml/badge.svg)](https://github.com/lf-edge/instantx/actions/workflows/codeql.yml)
 
 ### Table of Contents
 


### PR DESCRIPTION
Code scanning was in the "Needs setup" state. Add an advanced-setup CodeQL workflow rather than enabling default setup, so the analysis can cover the GitHub Actions workflows alongside the Python services and the website, run the security-extended query suite, and coexist with the existing bandit job.

bandit now emits SARIF and uploads it under its own category, so Python SAST findings become tracked alerts with dedup and dismissal history instead of a one-off red check. The upload is skipped for pull requests from forks, whose GITHUB_TOKEN is read-only; the pass/fail gate still blocks those PRs.

bandit exits 2 and writes an empty report when it cannot parse its config, so the step distinguishes findings (exit 1) from tool errors (exit >= 2) and hard -fails on the latter rather than uploading an empty report over the alerts. The toml extra keeps the pyproject.toml config parseable below Python 3.11.

<!-- Thanks for contributing to InstantX! Please read CONTRIBUTING.md before opening this PR. -->

## Description

<!-- What does this PR change and why? Link any related issue, e.g. "Closes #123". -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

## Checklist

- [x] I have read the [Contributing guidelines](../CONTRIBUTING.md).
- [x] **Tests added or updated** for the change (see the [Testing Policy](../CONTRIBUTING.md#testing-policy)), or I have explained below why tests are not applicable.
- [x] `poetry run pytest` passes locally.
- [x] `ruff check` and `bandit` report no new issues (see the [Development guide](../docs/Development.md)).
- [x] Documentation updated where relevant (README, `docs/`, `CHANGELOG.md`).
- [x] I am **not** including secrets, credentials, or sensitive data.
- [x] Security-impacting changes have been considered; vulnerabilities are reported privately via [SECURITY.md](../SECURITY.md), not in this PR.

## Notes for reviewers

<!-- Anything reviewers should pay special attention to. -->
